### PR TITLE
Toast should respect to the isParseLoginEmailAsUsername flag to avoid confusion

### DIFF
--- a/ParseLoginUI/src/com/parse/ui/ParseLoginFragment.java
+++ b/ParseLoginUI/src/com/parse/ui/ParseLoginFragment.java
@@ -166,7 +166,11 @@ public class ParseLoginFragment extends ParseLoginFragmentBase {
         String password = passwordField.getText().toString();
 
         if (username.length() == 0) {
-          showToast(R.string.com_parse_ui_no_username_toast);
+          if (config.isParseLoginEmailAsUsername()) {
+            showToast(R.string.com_parse_ui_no_email_toast);
+          } else {
+            showToast(R.string.com_parse_ui_no_username_toast);
+          }
         } else if (password.length() == 0) {
           showToast(R.string.com_parse_ui_no_password_toast);
         } else {

--- a/ParseLoginUI/src/com/parse/ui/ParseSignupFragment.java
+++ b/ParseLoginUI/src/com/parse/ui/ParseSignupFragment.java
@@ -153,7 +153,11 @@ public class ParseSignupFragment extends ParseLoginFragmentBase implements OnCli
     }
 
     if (username.length() == 0) {
-      showToast(R.string.com_parse_ui_no_username_toast);
+      if (config.isParseLoginEmailAsUsername()) {
+        showToast(R.string.com_parse_ui_no_email_toast);
+      } else {
+        showToast(R.string.com_parse_ui_no_username_toast);
+      }
     } else if (password.length() == 0) {
       showToast(R.string.com_parse_ui_no_password_toast);
     } else if (password.length() < minPasswordLength) {


### PR DESCRIPTION
If the flag ```isParseLoginEmailAsUsername```  has been turned on, the hint of the edit text box will be "email". So the toast message for the case that user not entering any characters should be 
"Please enter your email" rather than "Please enter your username" to avoid confusion.
