### PR TITLE
Fix User Signup w/ custom User Subclass

### DIFF
--- a/ParseUI-Login/src/main/java/com/parse/ui/ParseSignupFragment.java
+++ b/ParseUI-Login/src/main/java/com/parse/ui/ParseSignupFragment.java
@@ -33,6 +33,7 @@ import android.widget.EditText;
 import android.widget.ImageView;
 
 import com.parse.ParseException;
+import com.parse.ParseObject;
 import com.parse.ParseUser;
 import com.parse.SignUpCallback;
 
@@ -175,7 +176,7 @@ public class ParseSignupFragment extends ParseLoginFragmentBase implements OnCli
     } else if (name != null && name.length() == 0) {
       showToast(R.string.com_parse_ui_no_name_toast);
     } else {
-      ParseUser user = new ParseUser();
+      ParseUser user = ParseObject.create(ParseUser.class);
 
       // Set standard fields
       user.setUsername(username);


### PR DESCRIPTION
Signup would crash if a subclass of ParseUser was being used. Instead of instantiating ParseUser directly, find the correct subclass from the ParseObject subclass registration map.