### PR TITLE
Add ParseOnSignUpSuccessListener for sign up event

### DIFF
--- a/ParseUI-Login/src/main/java/com/parse/ui/ParseLoginActivity.java
+++ b/ParseUI-Login/src/main/java/com/parse/ui/ParseLoginActivity.java
@@ -71,7 +71,9 @@ import com.parse.ParseFacebookUtils;
 public class ParseLoginActivity extends FragmentActivity implements
     ParseLoginFragment.ParseLoginFragmentListener,
     ParseLoginHelpFragment.ParseOnLoginHelpSuccessListener,
-    ParseOnLoginSuccessListener, ParseOnLoadingListener {
+    ParseOnLoginSuccessListener,
+    ParseOnLoadingListener,
+    ParseOnSignupSuccessListener {
 
   public static final String LOG_TAG = "ParseLoginActivity";
 
@@ -157,13 +159,23 @@ public class ParseLoginActivity extends FragmentActivity implements
   }
 
   /**
-   * Called when the user successfully logs in or signs up.
+   * Called when the user successfully logs in.
    */
   @Override
   public void onLoginSuccess() {
     // This default implementation returns to the parent activity with
     // RESULT_OK.
-    // You can change this implementation if you want a different behavior.
+    setResult(RESULT_OK);
+    finish();
+  }
+
+  /**
+   * Called when the user successfully signs up.
+   */
+  @Override
+  public void onSignupSuccess() {
+    // This default implementation returns to the parent activity with
+    // RESULT_OK.
     setResult(RESULT_OK);
     finish();
   }

--- a/ParseUI-Login/src/main/java/com/parse/ui/ParseOnSignupSuccessListener.java
+++ b/ParseUI-Login/src/main/java/com/parse/ui/ParseOnSignupSuccessListener.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2014, Parse, LLC. All rights reserved.
+ *
+ *  You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ *  copy, modify, and distribute this software in source code or binary form for use
+ *  in connection with the web services and APIs provided by Parse.
+ *
+ *  As with any software that integrates with the Parse platform, your use of
+ *  this software is subject to the Parse Terms of Service
+ *  [https://www.parse.com/about/terms]. This copyright notice shall be
+ *  included in all copies or substantial portions of the software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ *  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ *  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ *  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+package com.parse.ui;
+
+public interface ParseOnSignupSuccessListener {
+  void onSignupSuccess();
+}

--- a/ParseUI-Login/src/main/java/com/parse/ui/ParseSignupFragment.java
+++ b/ParseUI-Login/src/main/java/com/parse/ui/ParseSignupFragment.java
@@ -49,7 +49,7 @@ public class ParseSignupFragment extends ParseLoginFragmentBase implements OnCli
   private EditText emailField;
   private EditText nameField;
   private Button createAccountButton;
-  private ParseOnLoginSuccessListener onLoginSuccessListener;
+  private ParseOnSignupSuccessListener onSignupSuccessListener;
 
   private ParseLoginConfig config;
   private int minPasswordLength;
@@ -119,8 +119,8 @@ public class ParseSignupFragment extends ParseLoginFragmentBase implements OnCli
   @Override
   public void onAttach(Activity activity) {
     super.onAttach(activity);
-    if (activity instanceof ParseOnLoginSuccessListener) {
-      onLoginSuccessListener = (ParseOnLoginSuccessListener) activity;
+    if (activity instanceof ParseOnSignupSuccessListener) {
+      onSignupSuccessListener = (ParseOnSignupSuccessListener) activity;
     } else {
       throw new IllegalArgumentException(
           "Activity must implemement ParseOnLoginSuccessListener");
@@ -230,6 +230,6 @@ public class ParseSignupFragment extends ParseLoginFragmentBase implements OnCli
   }
 
   private void signupSuccess() {
-    onLoginSuccessListener.onLoginSuccess();
+    onSignupSuccessListener.onSignupSuccess();
   }
 }


### PR DESCRIPTION
This PR is the first step of #79. We need to add ParseOnSignUpSuccessListener and then expose it to public.