### PR TITLE
Allow disable name field in signup form

### DIFF
--- a/ParseUI-Login/src/main/java/com/parse/ui/ParseLoginBuilder.java
+++ b/ParseUI-Login/src/main/java/com/parse/ui/ParseLoginBuilder.java
@@ -211,6 +211,18 @@ public class ParseLoginBuilder {
   }
 
   /**
+   * Whether to show the name field in the signup form. Default is true.
+   *
+   * @param enabled
+   *     Whether to show the name field in the signup form.
+   * @return The caller instance to allow chaining.
+   */
+  public ParseLoginBuilder setParseSignupNameFieldEnabled(boolean enabled) {
+    config.setParseSignupNameFieldEnabled(enabled);
+    return this;
+  }
+
+  /**
    * Whether to show the Facebook login option on the login screen. Default is
    * false.
    *

--- a/ParseUI-Login/src/main/java/com/parse/ui/ParseLoginConfig.java
+++ b/ParseUI-Login/src/main/java/com/parse/ui/ParseLoginConfig.java
@@ -47,6 +47,7 @@ public class ParseLoginConfig {
   public static final String PARSE_LOGIN_EMAIL_AS_USERNAME = "com.parse.ui.ParseLoginActivity.PARSE_LOGIN_EMAIL_AS_USERNAME";
   public static final String PARSE_SIGNUP_MIN_PASSWORD_LENGTH = "com.parse.ui.ParseLoginActivity.PARSE_SIGNUP_MIN_PASSWORD_LENGTH";
   public static final String PARSE_SIGNUP_SUBMIT_BUTTON_TEXT = "com.parse.ui.ParseLoginActivity.PARSE_SIGNUP_SUBMIT_BUTTON_TEXT";
+  public static final String PARSE_SIGNUP_NAME_FIELD_ENABLED = "com.parse.ui.ParseLoginActivity.PARSE_SIGNUP_NAME_FIELD_ENABLED";
   public static final String FACEBOOK_LOGIN_ENABLED = "com.parse.ui.ParseLoginActivity.FACEBOOK_LOGIN_ENABLED";
   public static final String FACEBOOK_LOGIN_BUTTON_TEXT = "com.parse.ui.ParseLoginActivity.FACEBOOK_LOGIN_BUTTON_TEXT";
   public static final String FACEBOOK_LOGIN_PERMISSIONS = "com.parse.ui.ParseLoginActivity.FACEBOOK_LOGIN_PERMISSIONS";
@@ -70,6 +71,7 @@ public class ParseLoginConfig {
   private Boolean parseLoginEmailAsUsername;
   private Integer parseSignupMinPasswordLength;
   private CharSequence parseSignupSubmitButtonText;
+  private Boolean parseSignupNameFieldEnabled;
 
   private Boolean facebookLoginEnabled;
   private CharSequence facebookLoginButtonText;
@@ -158,6 +160,18 @@ public class ParseLoginConfig {
   public void setParseSignupSubmitButtonText(
       CharSequence parseSignupSubmitButtonText) {
     this.parseSignupSubmitButtonText = parseSignupSubmitButtonText;
+  }
+
+  public Boolean isParseSignupNameFieldEnabled() {
+    if (parseSignupNameFieldEnabled != null) {
+      return parseSignupNameFieldEnabled;
+    } else {
+      return true;
+    }
+  }
+
+  public void setParseSignupNameFieldEnabled(Boolean parseSignupNameFieldEnabled) {
+    this.parseSignupNameFieldEnabled = parseSignupNameFieldEnabled;
   }
 
   public boolean isFacebookLoginEnabled() {
@@ -267,6 +281,9 @@ public class ParseLoginConfig {
       bundle.putCharSequence(PARSE_SIGNUP_SUBMIT_BUTTON_TEXT,
           parseSignupSubmitButtonText);
     }
+    if (parseSignupNameFieldEnabled != null) {
+      bundle.putBoolean(PARSE_SIGNUP_NAME_FIELD_ENABLED, parseSignupNameFieldEnabled);
+    }
 
     if (facebookLoginEnabled != null) {
       bundle.putBoolean(FACEBOOK_LOGIN_ENABLED, facebookLoginEnabled);
@@ -335,6 +352,9 @@ public class ParseLoginConfig {
     }
     if (keys.contains(PARSE_SIGNUP_SUBMIT_BUTTON_TEXT)) {
       config.setParseSignupSubmitButtonText(bundle.getCharSequence(PARSE_SIGNUP_SUBMIT_BUTTON_TEXT));
+    }
+    if (keys.contains(PARSE_SIGNUP_NAME_FIELD_ENABLED)) {
+      config.setParseSignupNameFieldEnabled(bundle.getBoolean(PARSE_SIGNUP_NAME_FIELD_ENABLED));
     }
 
     if (keys.contains(FACEBOOK_LOGIN_ENABLED)) {

--- a/ParseUI-Login/src/main/java/com/parse/ui/ParseSignupFragment.java
+++ b/ParseUI-Login/src/main/java/com/parse/ui/ParseSignupFragment.java
@@ -79,8 +79,8 @@ public class ParseSignupFragment extends ParseLoginFragmentBase implements OnCli
       minPasswordLength = config.getParseSignupMinPasswordLength();
     }
 
-    String username = (String) args.getString(USERNAME);
-    String password = (String) args.getString(PASSWORD);
+    String username = args.getString(USERNAME);
+    String password = args.getString(PASSWORD);
 
     View v = inflater.inflate(R.layout.com_parse_ui_parse_signup_fragment,
         parent, false);
@@ -91,6 +91,9 @@ public class ParseSignupFragment extends ParseLoginFragmentBase implements OnCli
         .findViewById(R.id.signup_confirm_password_input);
     emailField = (EditText) v.findViewById(R.id.signup_email_input);
     nameField = (EditText) v.findViewById(R.id.signup_name_input);
+    if (!config.isParseSignupNameFieldEnabled()) {
+      nameField.setVisibility(View.INVISIBLE);
+    }
     createAccountButton = (Button) v.findViewById(R.id.create_account);
 
     usernameField.setText(username);
@@ -172,7 +175,7 @@ public class ParseSignupFragment extends ParseLoginFragmentBase implements OnCli
       confirmPasswordField.requestFocus();
     } else if (email != null && email.length() == 0) {
       showToast(R.string.com_parse_ui_no_email_toast);
-    } else if (name != null && name.length() == 0) {
+    } else if (name != null && name.length() == 0 && config.isParseSignupNameFieldEnabled()) {
       showToast(R.string.com_parse_ui_no_name_toast);
     } else {
       ParseUser user = new ParseUser();
@@ -183,7 +186,7 @@ public class ParseSignupFragment extends ParseLoginFragmentBase implements OnCli
       user.setEmail(email);
 
       // Set additional custom fields only if the user filled it out
-      if (name.length() != 0) {
+      if (name.length() != 0 && config.isParseSignupNameFieldEnabled()) {
         user.put(USER_OBJECT_NAME_FIELD, name);
       }
 


### PR DESCRIPTION
Allow users to disable name field in the signup form #43 
Developers now can disable the name field 
1.In the  `AndroidManifest.xml`
```xml
<activity
    android:name="com.parse.ui.ParseLoginActivity"
    android:label="@string/app_name"
    android:launchMode="singleTop">
    <meta-data
        android:name="com.parse.ui.ParseLoginActivity.PARSE_SIGNUP_NAME_FIELD_ENABLED"
        android:value="false"/>
</activity>
```
2.In `ParseLoginBuilder`
```java
ParseLoginBuilder loginBuilder = new ParseLoginBuilder(getApplicationContext());
loginBuilder.setParseSignupNameFieldEnabled(false);
```
![image](https://cloud.githubusercontent.com/assets/4666935/11258152/b1ed6fde-8e0b-11e5-9546-79d0cb0b0a40.png)

Test:
1. Do the configuration in `AndroidManifest.xml`, check whether the name field disable or not, check wether we can signup or not
2. Do the configuration in `ParseLoginBuilder`, check whether the name field disable or not, check wether we can signup or not
3. Do not do any configuration, make sure the name field shows and we can signup