### PR TITLE
Allow pass extras to target activity

### DIFF
--- a/ParseUI-Login/src/main/java/com/parse/ui/ParseLoginDispatchActivity.java
+++ b/ParseUI-Login/src/main/java/com/parse/ui/ParseLoginDispatchActivity.java
@@ -88,7 +88,12 @@ public abstract class ParseLoginDispatchActivity extends Activity {
   private void runDispatch() {
     if (ParseUser.getCurrentUser() != null) {
       debugLog(getString(R.string.com_parse_ui_login_dispatch_user_logged_in) + getTargetClass());
-      startActivityForResult(new Intent(this, getTargetClass()), TARGET_REQUEST);
+      Intent targetIntent = new Intent(this, getTargetClass());
+      Bundle extras = getIntent().getExtras();
+      if (extras != null) {
+        targetIntent.putExtras(extras);
+      }
+      startActivityForResult(targetIntent, TARGET_REQUEST);
     } else {
       debugLog(getString(R.string.com_parse_ui_login_dispatch_user_not_logged_in));
       startActivityForResult(getParseLoginIntent(), LOGIN_REQUEST);


### PR DESCRIPTION
Currently, if we use `ParseLoginDispatchActivity`, we build an empty intent to start the target Activity. This changes allow us to pass extra bundle to the target Activity. #15.

Test with `ParseLoginSampleWithDispatchActivity` sample app.