### PR TITLE
trim username on login/signup

### DIFF
--- a/ParseUI-Login/src/main/java/com/parse/ui/ParseLoginFragment.java
+++ b/ParseUI-Login/src/main/java/com/parse/ui/ParseLoginFragment.java
@@ -166,7 +166,7 @@ public class ParseLoginFragment extends ParseLoginFragmentBase {
     parseLoginButton.setOnClickListener(new OnClickListener() {
       @Override
       public void onClick(View v) {
-        String username = usernameField.getText().toString();
+        String username = usernameField.getText().toString().trim();
         String password = passwordField.getText().toString();
 
         if (username.length() == 0) {

--- a/ParseUI-Login/src/main/java/com/parse/ui/ParseSignupFragment.java
+++ b/ParseUI-Login/src/main/java/com/parse/ui/ParseSignupFragment.java
@@ -139,7 +139,7 @@ public class ParseSignupFragment extends ParseLoginFragmentBase implements OnCli
 
   @Override
   public void onClick(View v) {
-    String username = usernameField.getText().toString();
+    String username = usernameField.getText().toString().trim();
     String password = passwordField.getText().toString();
     String passwordAgain = confirmPasswordField.getText().toString();
 


### PR DESCRIPTION
When a user selects an auto-completed word, Android adds a space to the end. Less observant users may not notice this extra space and have trouble logging in after creating a username with a trailing space.