### PR TITLE
Login autocomplete now disabled

### DIFF
--- a/ParseUI-Login/src/main/res/layout/com_parse_ui_parse_login_form.xml
+++ b/ParseUI-Login/src/main/res/layout/com_parse_ui_parse_login_form.xml
@@ -11,7 +11,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         style="@style/ParseLoginUI.EditText"
-        android:hint="@string/com_parse_ui_username_input_hint" />
+        android:hint="@string/com_parse_ui_username_input_hint"
+		android:inputType="textVisiblePassword"/>
 
     <EditText
         android:id="@+id/login_password_input"


### PR DESCRIPTION
Autocomplete in login field is very disturbing. This little patch is  safe in combination with email as login, look setUpParseLoginAndSignup in ParseLoginFragment.java, it setting up special input type in case of email as login.